### PR TITLE
Minor fixes

### DIFF
--- a/src/Internals/ProgressBarWorker/HasChannels.php
+++ b/src/Internals/ProgressBarWorker/HasChannels.php
@@ -27,6 +27,8 @@ trait HasChannels {
     }
 
     protected function release(): void {
+        if ( !PARALLEL_EXT_LOADED) return;
+
         $this->progressbar_channel->release();
     }
 

--- a/src/Internals/Worker/CommunicatesWithProgressBarWorker.php
+++ b/src/Internals/Worker/CommunicatesWithProgressBarWorker.php
@@ -56,6 +56,9 @@ trait CommunicatesWithProgressBarWorker {
     }
 
     private function newProgressBarAction(string $action, ...$args): void {
+        // check if progressbar is active
+        if ($this->progressbar_channel === null) return;
+
         $message = new Commands\ProgressBar\ProgressBarActionMessage(
             action: $action,
             args:   $args,

--- a/src/ParallelWorker.php
+++ b/src/ParallelWorker.php
@@ -32,7 +32,7 @@ abstract class ParallelWorker implements Contracts\ParallelWorker {
     /**
      * @var mixed Worker execution result
      */
-    private mixed $result;
+    private mixed $result = null;
 
     final public function getState(): int {
         return $this->state;

--- a/tests/ParallelTest.php
+++ b/tests/ParallelTest.php
@@ -122,6 +122,7 @@ final class ParallelTest extends TestCase {
         }
     }
 
+    /** @depends testThatParallelExtensionIsAvailable */
     public function testThatTasksCanBeRemovedFromQueue(): void {
         Scheduler::using(Workers\LongRunningWorker::class);
 
@@ -155,6 +156,7 @@ final class ParallelTest extends TestCase {
         Scheduler::removeAllTasks();
     }
 
+    /** @depends testThatParallelExtensionIsAvailable */
     public function testThatTasksCanBeCancelled(): void {
         Scheduler::using(Workers\LongRunningWorker::class);
 
@@ -185,6 +187,7 @@ final class ParallelTest extends TestCase {
         Scheduler::removeAllTasks();
     }
 
+    /** @depends testThatParallelExtensionIsAvailable */
     public function testThatChannelsDontOverlap(): void {
         Scheduler::using(Workers\WorkerWithSubWorkers::class);
 


### PR DESCRIPTION
- FIX: Check if progress bar channel is open before sending a ProgressBar action
- FIX: Set default Task result as null
- FIX: Check if extension is available before using ProgressBarWorker channels